### PR TITLE
feat: show original recorded/released year mined from album descriptions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,20 @@ is deliberately not displayed.
 Keep this module free of lookbehind and other post-ES5 regex syntax: `tsconfig` targets es5, regex syntax
 can't be down-levelled, and this module is imported by client components on the homepage.
 
+**Correcting a wrong year** — add `"originalReleaseYear"` to the feed's entry in `data/feeds.json`, never
+by editing `public/static-albums.json`, which any cache rebuild overwrites:
+- `"originalReleaseYear": 1998` forces that year;
+- `"originalReleaseYear": null` suppresses a bad auto-detected date and falls back to the pubDate year;
+- key absent leaves the extractor in charge.
+
+`resolveOriginalRelease(extracted, overrideYear)` applies it, and every writer that merges feed metadata
+onto an album calls it: `scripts/regenerate-static-cache-direct.ts`, `scripts/backfill-album-dates.ts`,
+`app/api/admin/manage-feeds/route.ts` (via `prepareAlbumFilesForAdd`), and the live-parse fallback in
+`app/api/album/[id]/route.ts`. Add the call to any new writer, or curated years silently vanish there.
+
+Singles are the coverage gap: 25 of the 50 entries are single-track and **none** state a date in the
+description, so they all show the feed year. Fixing those needs the override above or another data source.
+
 ### Video player and shuffle
 - `contexts/VideoContext.tsx` owns video play state, separate from `AudioContext`. The global now-playing bar (`components/GlobalNowPlayingBar.tsx`) reads from whichever has a current item.
 - `components/VideoPlayer.tsx` accepts `externalIsPlaying` to sync the DOM `<video>` element with `VideoContext.isPlaying` (so the bottom-bar play/pause actually drives the video).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ Three JSON files in `public/` serve the album list and must stay consistent:
 - `albums-static-cached.json` — secondary cache, written alongside `static-albums.json` by admin endpoints. Drift here is the bug source for duplicate-album incidents.
 - `album-index.json` — slug → array-position lookup built from `static-albums.json`. Rebuild after any edit with `node scripts/build-album-index.js`.
 
-Writers: `app/api/admin/manage-feeds/route.ts` (POST/PUT/DELETE), `scripts/regenerate-static-cache-direct.ts` (full rebuild from `data/feeds.json`), `scripts/reparse-affected.ts` (single- or multi-feed reparse with assertions).
+Writers: `app/api/admin/manage-feeds/route.ts` (POST/PUT/DELETE), `scripts/regenerate-static-cache-direct.ts` (full rebuild from `data/feeds.json`), `scripts/reparse-affected.ts` (single- or multi-feed reparse with assertions), `scripts/backfill-album-dates.ts` (re-derives `originalRelease` from cached description text, no network).
 
 ### Admin route writes must be Vercel-aware
 On Vercel the project filesystem is read-only, so any admin handler that mutates `data/*.json` or `public/*.json` must commit through GitHub — a raw `fs.writeFileSync` either throws `EROFS` or lands in per-instance tmpfs and silently disappears. Pattern (see `app/api/admin/manage-feeds/route.ts:11-107` and `app/api/admin/pinned-albums/route.ts`):
@@ -62,6 +62,23 @@ Feeds not indexed on Podcast Index get `"originalUrl": "PRIVATE_FEED_URL"` redac
 
 ### Shared album-index utilities (`lib/album-index.ts`)
 `createSlug(title)` and `buildAlbumIndex(albums)` are the single source of truth for slug generation and the lookup index. Import from here rather than reimplementing inline. `scripts/build-album-index.js` keeps a parallel JS copy for plain-`node` invocation — keep both in lockstep.
+
+### Display year comes from the description, not the pubDate (`lib/album-date.ts`)
+An album's `releaseDate` is the feed's RSS pubDate — when the v4v feed went up, often years after the
+music was made (`Them` has a 2026 pubDate for a 2019 record). `extractAlbumDate(description)` mines the
+stated recorded/released date out of the description text and the parser stores it as `originalRelease`;
+`getDisplayYear(album)` prefers it and falls back to the pubDate year. Use `getDisplayYear` at every
+year-display site — do not reintroduce inline `new Date(album.releaseDate).getFullYear()`.
+
+The extractor is context-aware on purpose: it skips sentences about births, deaths and weddings, and
+strips `YYYY-YYYY` lifespans, because real descriptions contain those (`Autumn`'s "born Jan 12, 2024",
+`Unsound Existence`'s "Miles Fonda 1988-2023"). Its expected output for all 9 matching albums is asserted
+in `scripts/backfill-album-dates.ts`, which is the repo's stand-in for a unit test here — run it after
+touching the extractor. The stored `kind` ('recorded' vs 'released') is lower-confidence than `year` and
+is deliberately not displayed.
+
+Keep this module free of lookbehind and other post-ES5 regex syntax: `tsconfig` targets es5, regex syntax
+can't be down-levelled, and this module is imported by client components on the homepage.
 
 ### Video player and shuffle
 - `contexts/VideoContext.tsx` owns video play state, separate from `AudioContext`. The global now-playing bar (`components/GlobalNowPlayingBar.tsx`) reads from whichever has a current item.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,8 +88,12 @@ by editing `public/static-albums.json`, which any cache rebuild overwrites:
 
 `resolveOriginalRelease(extracted, overrideYear)` applies it, and every writer that merges feed metadata
 onto an album calls it: `scripts/regenerate-static-cache-direct.ts`, `scripts/backfill-album-dates.ts`,
-`app/api/admin/manage-feeds/route.ts` (via `prepareAlbumFilesForAdd`), and the live-parse fallback in
-`app/api/album/[id]/route.ts`. Add the call to any new writer, or curated years silently vanish there.
+`scripts/reparse-affected.ts`, `scripts/reparse-them.ts`, `app/api/admin/manage-feeds/route.ts` (via
+`prepareAlbumFilesForAdd`), and the live-parse fallback in `app/api/album/[id]/route.ts`. These writers
+replace the whole cache entry, so a writer that skips the call silently drops the curated year — add it
+to any new writer. Scripts read the overrides via `loadOriginalReleaseOverrides()` in
+`scripts/feed-overrides.ts`; it uses `fs`, which is why it lives there and not in the client-safe
+`lib/album-date.ts`.
 
 Singles are the coverage gap: 25 of the 50 entries are single-track and **none** state a date in the
 description, so they all show the feed year. Fixing those needs the override above or another data source.

--- a/app/album/[id]/AlbumDetailClient.tsx
+++ b/app/album/[id]/AlbumDetailClient.tsx
@@ -12,6 +12,7 @@ import VideoPlayer from '@/components/VideoPlayer';
 import { BitcoinConnectPayment } from '@/components/BitcoinConnect';
 import type { RSSValue } from '@/lib/rss-parser';
 import { createSlug } from '@/lib/album-index';
+import { getDisplayYear, type AlbumDateInfo } from '@/lib/album-date';
 import dynamic from 'next/dynamic';
 import { filterPodrollItems } from '@/lib/podroll-utils';
 import confetti from 'canvas-confetti';
@@ -79,6 +80,7 @@ interface Album {
   coverArt: string;
   tracks: Track[];
   releaseDate: string;
+  originalRelease?: AlbumDateInfo;
   feedId: string;
   feedUrl?: string;
   funding?: RSSFunding[];
@@ -1051,11 +1053,7 @@ export default function AlbumDetailClient({ albumTitle, initialAlbum }: AlbumDet
 
   const getReleaseYear = () => {
     if (!album) return '';
-    try {
-      return new Date(album.releaseDate).getFullYear();
-    } catch {
-      return '';
-    }
+    return getDisplayYear(album);
   };
 
   const getAlbumSlug = (albumData: Album) => {

--- a/app/api/admin/manage-feeds/route.ts
+++ b/app/api/admin/manage-feeds/route.ts
@@ -5,6 +5,7 @@ import { validateSession } from '@/lib/admin-auth';
 import { commitFiles, isGitHubConfigured } from '@/lib/github';
 import { checkFeedOnPodcastIndex } from '@/lib/podcast-index';
 import { buildAlbumIndex } from '@/lib/album-index';
+import { resolveOriginalRelease } from '@/lib/album-date';
 import fs from 'fs';
 import path from 'path';
 
@@ -110,11 +111,17 @@ async function writeFiles(files: { path: string; content: string }[], commitMess
 function prepareAlbumFilesForAdd(album: any, feedUrl: string, feedId: string): { path: string; content: string }[] {
   const files: { path: string; content: string }[] = [];
 
+  // A curated originalReleaseYear in feeds.json beats the date mined from the
+  // description, so hand-corrected years survive an admin re-parse.
+  const feedsForOverride = readJsonFile<FeedsData>(FEEDS_PATH, { feeds: [], lastUpdated: '', version: 1 });
+  const overrideEntry = feedsForOverride.feeds?.find(f => f.id === feedId);
+
   // Prepare album with feed metadata
   const albumWithMeta = {
     ...album,
     feedId,
     feedUrl,
+    originalRelease: resolveOriginalRelease(album.originalRelease, overrideEntry?.originalReleaseYear),
     lastUpdated: new Date().toISOString()
   };
 

--- a/app/api/album/[id]/route.ts
+++ b/app/api/album/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { FeedManager } from '@/lib/feed-manager';
 import { RSSParser } from '@/lib/rss-parser';
 import { createSlug } from '@/lib/album-index';
+import { resolveOriginalRelease } from '@/lib/album-date';
 
 // Cache for individual albums to avoid repeated RSS parsing
 let albumCache: Map<string, { data: any; timestamp: number }> = new Map();
@@ -223,6 +224,12 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
       ...albumData,
       feedId: matchingFeed.id,
       feedUrl: matchingFeed.originalUrl,
+      // Honour a curated originalReleaseYear on this live-parse fallback too,
+      // so it matches what the cached path serves.
+      originalRelease: resolveOriginalRelease(
+        albumData.originalRelease,
+        (matchingFeed as any).originalReleaseYear
+      ),
       lastUpdated: matchingFeed.lastUpdated
     };
     

--- a/app/api/album/[id]/route.ts
+++ b/app/api/album/[id]/route.ts
@@ -228,7 +228,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
       // so it matches what the cached path serves.
       originalRelease: resolveOriginalRelease(
         albumData.originalRelease,
-        (matchingFeed as any).originalReleaseYear
+        matchingFeed.originalReleaseYear
       ),
       lastUpdated: matchingFeed.lastUpdated
     };

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import LoadingSpinner from '@/components/LoadingSpinner';
 import { getVersionString } from '@/lib/version';
+import { getDisplayYear, type AlbumDateInfo } from '@/lib/album-date';
 import { useAudio } from '@/contexts/AudioContext';
 import { useVideo } from '@/contexts/VideoContext';
 import { useLightning } from '@/contexts/LightningContext';
@@ -92,6 +93,7 @@ interface Album {
   coverArt: string;
   tracks: Track[];
   releaseDate: string;
+  originalRelease?: AlbumDateInfo;
   feedId: string;
   feedUrl?: string;
   funding?: RSSFunding[];
@@ -1419,7 +1421,7 @@ export default function HomePage() {
                                 </div>
                                 
                                 <div className="flex items-center gap-4 text-sm text-gray-400">
-                                  <span>{new Date(album.releaseDate).getFullYear()}</span>
+                                  <span>{getDisplayYear(album)}</span>
                                   <span>{album.tracks.length} tracks</span>
                                   <span className="px-2 py-1 bg-white/10 rounded text-xs">Album</span>
                                 </div>
@@ -1475,7 +1477,7 @@ export default function HomePage() {
                                 </div>
                                 
                                 <div className="flex items-center gap-4 text-sm text-gray-400">
-                                  <span>{new Date(album.releaseDate).getFullYear()}</span>
+                                  <span>{getDisplayYear(album)}</span>
                                   <span>{album.tracks.length} tracks</span>
                                   <span className="px-2 py-1 bg-white/10 rounded text-xs">
                                     {album.tracks.length === 1 ? 'Single' : 'EP'}
@@ -1529,7 +1531,7 @@ export default function HomePage() {
                         </div>
                         
                         <div className="flex items-center gap-4 text-sm text-gray-400">
-                          <span>{new Date(album.releaseDate).getFullYear()}</span>
+                          <span>{getDisplayYear(album)}</span>
                           <span>{album.tracks.length} tracks</span>
                           <span className="px-2 py-1 bg-white/10 rounded text-xs">
                             {album.tracks.length <= 6 ? (album.tracks.length === 1 ? 'Single' : 'EP') : 'Album'}

--- a/app/publisher/[name]/PublisherDetailClient.tsx
+++ b/app/publisher/[name]/PublisherDetailClient.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { ArrowLeft } from 'lucide-react';
 import { useAudio } from '@/contexts/AudioContext';
+import { getDisplayYear, type AlbumDateInfo } from '@/lib/album-date';
 
 interface Track {
   title: string;
@@ -21,6 +22,7 @@ interface Album {
   coverArt: string;
   tracks: Track[];
   releaseDate: string;
+  originalRelease?: AlbumDateInfo;
   feedId: string;
   feedUrl?: string;
   funding?: any[];
@@ -153,13 +155,7 @@ export default function PublisherDetailClient({ publisherName, initialPublisher 
       .replace(/^-+|-+$/g, '');
   };
 
-  const getReleaseYear = (releaseDate: string) => {
-    try {
-      return new Date(releaseDate).getFullYear();
-    } catch {
-      return '';
-    }
-  };
+  const getReleaseYear = (album: Album) => getDisplayYear(album);
 
   const handlePlayAlbum = (album: Album, e: React.MouseEvent) => {
     e.preventDefault(); // Prevent navigation when clicking play button
@@ -338,8 +334,8 @@ export default function PublisherDetailClient({ publisherName, initialPublisher 
                         {album.title}
                       </h3>
                       <p className="text-xs text-gray-400 truncate">{album.artist}</p>
-                      {album.releaseDate && (
-                        <p className="text-xs text-gray-500 mt-1">{getReleaseYear(album.releaseDate)}</p>
+                      {getReleaseYear(album) && (
+                        <p className="text-xs text-gray-500 mt-1">{getReleaseYear(album)}</p>
                       )}
                     </div>
                   </Link>

--- a/components/AlbumCard.tsx
+++ b/components/AlbumCard.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { Play, Pause, Music, Zap, Video } from 'lucide-react';
 import type { RSSValue, RSSValueRecipient } from '@/lib/rss-parser';
+import { getDisplayYear, type AlbumDateInfo } from '@/lib/album-date';
 import { useLightning } from '@/contexts/LightningContext';
 import CDNImage from '@/components/CDNImage';
 
@@ -33,6 +34,7 @@ interface Album {
   coverArt: string;
   tracks: Track[];
   releaseDate: string;
+  originalRelease?: AlbumDateInfo;
   feedId: string;
   feedUrl?: string;
   funding?: any[];
@@ -299,9 +301,9 @@ function AlbumCard({ album, isPlaying = false, onPlay, onBoostClick, className =
         
         {/* Release date and publisher indicator */}
         <div className="flex items-center justify-between mt-0.5 sm:mt-1">
-          {album.releaseDate && (
+          {getDisplayYear(album) && (
             <p className="text-gray-400 text-[10px] sm:text-xs">
-              {new Date(album.releaseDate).getFullYear()}
+              {getDisplayYear(album)}
             </p>
           )}
         </div>

--- a/components/AlbumCard.tsx
+++ b/components/AlbumCard.tsx
@@ -68,6 +68,7 @@ function AlbumCard({ album, isPlaying = false, onPlay, onBoostClick, className =
   const [touchStart, setTouchStart] = useState<number | null>(null);
   const [touchEnd, setTouchEnd] = useState<number | null>(null);
 
+  const displayYear = getDisplayYear(album);
 
   // Minimum swipe distance (in px)
   const minSwipeDistance = 50;
@@ -301,9 +302,9 @@ function AlbumCard({ album, isPlaying = false, onPlay, onBoostClick, className =
         
         {/* Release date and publisher indicator */}
         <div className="flex items-center justify-between mt-0.5 sm:mt-1">
-          {getDisplayYear(album) && (
+          {displayYear && (
             <p className="text-gray-400 text-[10px] sm:text-xs">
-              {getDisplayYear(album)}
+              {displayYear}
             </p>
           )}
         </div>

--- a/lib/album-date.ts
+++ b/lib/album-date.ts
@@ -1,0 +1,135 @@
+/**
+ * Shared album-date utilities. Single source of truth for pulling the original
+ * recorded/released date out of an album description, and for deciding which
+ * year the UI should display.
+ *
+ * Why this exists: an album's `releaseDate` comes from the feed's RSS pubDate,
+ * which is when the v4v feed was published — not when the music was made. Many
+ * descriptions state the real date ("recorded in 2015", "originally released in
+ * 2017"), so we mine that and prefer it, falling back to pubDate when absent.
+ *
+ * Pure functions only — no Node APIs — so client components can import this.
+ */
+
+export type AlbumDateKind = 'recorded' | 'released';
+
+export interface AlbumDateInfo {
+  /** The stated year, e.g. 2017. */
+  year: number;
+  /** Whether the surrounding wording read as a recording or a release. Lower confidence than `year`. */
+  kind: AlbumDateKind;
+  /** 'day' when a full "Month D, YYYY" was stated, otherwise 'year'. */
+  precision: 'year' | 'day';
+  /** The phrase the year was taken from, kept for provenance and debugging. */
+  source: string;
+}
+
+const MIN_YEAR = 1950;
+
+const MONTHS =
+  '(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sept?(?:ember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)';
+
+/**
+ * Contexts in which a year is about a person or an event, never the album.
+ * A sentence matching any of these is skipped wholesale — e.g. "our daughter,
+ * Autumn, born Jan 12, 2024" and "Ben married Dougs daughter, Emma in 2020".
+ */
+const NEGATIVE_CONTEXT =
+  /\b(born|birth(?:day|s)?|died|death|passed away|in memory|memoriam|dedicated|rip|r\.i\.p\.|married|marriage|wedding|anniversary|founded|graduat)/i;
+
+/** A YYYY-YYYY span is a lifespan or an era, never a single album date. */
+const YEAR_RANGE = /\b(?:19|20)\d{2}\s*[-–—]\s*(?:19|20)\d{2}\b/g;
+
+const RECORDED_WORDS = /\b(record(?:ed|ing)?|tracked|laid down|captured?|jam(?:med)?|live|concert|session)\b/i;
+const RELEASE_VERBS = /\b(releas(?:e|ed|ing)|came out|dropped|put out|debut(?:ed)?|premiered?)\b/i;
+/** Nouns that make a sentence album-related but say nothing about recorded vs released. */
+const RELEASE_NOUNS = /\b(album|ep)\b/i;
+const DATE_CONTEXT = new RegExp(
+  `${RECORDED_WORDS.source}|${RELEASE_VERBS.source}|${RELEASE_NOUNS.source}`,
+  'i'
+);
+
+/** How close (in characters) a year must sit to a recording/release word to count. */
+const PROXIMITY = 120;
+
+const YEAR = /\b(19[5-9]\d|20[0-4]\d)\b/g;
+
+/**
+ * Split into sentences, keeping the terminating punctuation.
+ * Deliberately avoids lookbehind: tsconfig targets es5 and regex syntax can't be
+ * down-levelled, so a lookbehind literal would throw SyntaxError on Safari < 16.4
+ * and take the whole module — and any page importing it — down with it.
+ */
+function splitSentences(text: string): string[] {
+  return (text.match(/[^.!?\n]+[.!?]*/g) || []).map((s) => s.trim()).filter(Boolean);
+}
+
+/**
+ * Pull the original recorded/released date out of an album description.
+ * Returns null when the description states no date — which is the common case.
+ */
+export function extractAlbumDate(description?: string | null): AlbumDateInfo | null {
+  if (!description) return null;
+
+  const text = description.replace(/\s+/g, ' ').trim();
+  const maxYear = new Date().getFullYear();
+  const candidates: AlbumDateInfo[] = [];
+
+  for (const rawSentence of splitSentences(text)) {
+    // A sentence about a birth, death or wedding tells us nothing about the album.
+    if (NEGATIVE_CONTEXT.test(rawSentence)) continue;
+
+    // Blank out lifespans so "Miles Fonda 1988-2023" contributes no candidate years.
+    const sentence = rawSentence.replace(YEAR_RANGE, ' ');
+    if (!DATE_CONTEXT.test(sentence)) continue;
+
+    YEAR.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = YEAR.exec(sentence)) !== null) {
+      const year = parseInt(match[1], 10);
+      if (year < MIN_YEAR || year > maxYear) continue;
+
+      // The year has to sit near the recording/release wording, not merely in
+      // the same sentence — long sentences otherwise produce false matches.
+      const window = sentence.slice(Math.max(0, match.index - PROXIMITY), match.index + PROXIMITY);
+      if (!DATE_CONTEXT.test(window)) continue;
+
+      // "recorded in 2015" reads as a recording; an explicit release verb wins that label.
+      // The bare nouns "album"/"ep" deliberately don't decide this either way.
+      const kind: AlbumDateKind =
+        RECORDED_WORDS.test(window) && !RELEASE_VERBS.test(window) ? 'recorded' : 'released';
+
+      // A full "Dec 2, 2025" immediately before the year means we know the day.
+      const preceding = sentence.slice(Math.max(0, match.index - 20), match.index);
+      const hasMonthDay = new RegExp(`${MONTHS}\\.?\\s+\\d{1,2}(?:st|nd|rd|th)?,?\\s*$`, 'i').test(preceding);
+
+      candidates.push({
+        year,
+        kind,
+        precision: hasMonthDay ? 'day' : 'year',
+        source: sentence.slice(Math.max(0, match.index - 60), match.index + 20).trim(),
+      });
+    }
+  }
+
+  if (candidates.length === 0) return null;
+
+  // Earliest year wins: we want the original recording, not a later re-release.
+  candidates.sort((a, b) => a.year - b.year);
+  return candidates[0];
+}
+
+/**
+ * The year to show for an album: the date stated in its description when we
+ * found one, otherwise the feed's pubDate year. Returns '' if neither parses.
+ */
+export function getDisplayYear(album: {
+  originalRelease?: AlbumDateInfo | null;
+  releaseDate?: string;
+}): string {
+  if (album?.originalRelease?.year) return String(album.originalRelease.year);
+
+  if (!album?.releaseDate) return '';
+  const parsed = new Date(album.releaseDate);
+  return isNaN(parsed.getTime()) ? '' : String(parsed.getFullYear());
+}

--- a/lib/album-date.ts
+++ b/lib/album-date.ts
@@ -120,6 +120,32 @@ export function extractAlbumDate(description?: string | null): AlbumDateInfo | n
 }
 
 /**
+ * Apply a hand-curated `originalReleaseYear` from a data/feeds.json entry on top
+ * of whatever the extractor found. This is how a wrong or unwanted auto-detected
+ * date gets corrected — edits made directly to public/static-albums.json are
+ * silently discarded the next time the cache is regenerated from the feeds.
+ *
+ *   "originalReleaseYear": 2017   -> force that year
+ *   "originalReleaseYear": null   -> suppress the extracted date; fall back to pubDate
+ *   (key absent)                  -> keep whatever the extractor found
+ */
+export function resolveOriginalRelease(
+  extracted: AlbumDateInfo | undefined | null,
+  overrideYear?: number | null
+): AlbumDateInfo | undefined {
+  if (overrideYear === null) return undefined;
+  if (typeof overrideYear === 'number' && !isNaN(overrideYear)) {
+    return {
+      year: overrideYear,
+      kind: 'released',
+      precision: 'year',
+      source: 'manual override (data/feeds.json)',
+    };
+  }
+  return extracted || undefined;
+}
+
+/**
  * The year to show for an album: the date stated in its description when we
  * found one, otherwise the feed's pubDate year. Returns '' if neither parses.
  */

--- a/lib/feed-manager.ts
+++ b/lib/feed-manager.ts
@@ -9,6 +9,11 @@ export interface Feed {
   priority: 'core' | 'extended' | 'low';
   status: 'active' | 'inactive';
   trackFilter?: string; // Optional filter to only include tracks matching this string (e.g., artist name)
+  // Hand-curated release year that overrides the date mined from the album description
+  // (see lib/album-date.ts). Set to null to suppress a wrong auto-detected date and fall
+  // back to the feed's pubDate year. Editing public/static-albums.json directly does not
+  // survive a cache rebuild — correct it here instead.
+  originalReleaseYear?: number | null;
   addedAt: string;
   lastUpdated: string;
   isPrivate?: boolean; // True if feed is not indexed on Podcast Index

--- a/lib/rss-parser.ts
+++ b/lib/rss-parser.ts
@@ -1,5 +1,6 @@
 import { AppError, ErrorCodes, withRetry, createErrorLogger } from './error-utils';
 import { RSSCache } from './rss-cache';
+import { extractAlbumDate, AlbumDateInfo } from './album-date';
 
 export interface RSSTrack {
   title: string;
@@ -74,6 +75,12 @@ export interface RSSAlbum {
   coverArt: string | null;
   tracks: RSSTrack[];
   releaseDate: string;
+  /**
+   * Original recorded/released date mined from the description, when stated.
+   * `releaseDate` is the feed's pubDate (when the v4v feed went up), which is
+   * often years after the music was made — prefer this for display.
+   */
+  originalRelease?: AlbumDateInfo;
   duration?: string;
   link?: string;
   funding?: RSSFunding[];
@@ -1459,13 +1466,18 @@ export class RSSParser {
       // Reorder: audio tracks first, then chapter tracks, then [Raw Set] videos at the bottom
       filteredTracks = [...otherTracks, ...chapterTracks, ...rawSetTracks];
 
+      const cleanDescription = cleanHtmlContent(description) || '';
+
       const album = {
         title,
         artist,
-        description: cleanHtmlContent(description) || '',
+        description: cleanDescription,
         coverArt,
         tracks: filteredTracks,
         releaseDate,
+        // Many descriptions state when the music was actually recorded/released,
+        // which the feed's pubDate does not tell us.
+        originalRelease: extractAlbumDate(cleanDescription) || undefined,
         link,
         funding: funding.length > 0 ? funding : undefined,
         value: value,

--- a/public/album-index.json
+++ b/public/album-index.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "totalAlbums": 50,
-  "indexedAt": "2026-08-04T19:34:44.438Z",
+  "indexedAt": "2026-08-04T19:45:10.143Z",
   "index": {
     "disco swag - the album": {
       "title": "Disco Swag - The Album",

--- a/public/album-index.json
+++ b/public/album-index.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "totalAlbums": 50,
-  "indexedAt": "2026-04-29T23:18:58.432Z",
+  "indexedAt": "2026-08-04T19:34:44.438Z",
   "index": {
     "disco swag - the album": {
       "title": "Disco Swag - The Album",

--- a/public/albums-static-cached.json
+++ b/public/albums-static-cached.json
@@ -976,7 +976,13 @@
       "imageUrl": "https://www.doerfelverse.com/art/them.png",
       "feedId": "www-doerfelverse-com-feeds-them-xml",
       "priority": "extended",
-      "lastUpdated": "2026-04-29T23:18:58.411Z"
+      "lastUpdated": "2026-04-29T23:18:58.411Z",
+      "originalRelease": {
+        "year": 2019,
+        "kind": "released",
+        "precision": "year",
+        "source": "eased when we went by the band name, \"Fuel on Fire\" back in 2019."
+      }
     },
     {
       "title": "The Satellite Spotlight",

--- a/public/static-albums.json
+++ b/public/static-albums.json
@@ -4636,7 +4636,13 @@
       "imageUrl": "https://www.doerfelverse.com/art/think-ep.png",
       "feedId": "www-doerfelverse-com-feeds-think-ep-xml",
       "priority": "core",
-      "lastUpdated": "2025-12-14T16:26:12.527Z"
+      "lastUpdated": "2025-12-14T16:26:12.527Z",
+      "originalRelease": {
+        "year": 2017,
+        "kind": "released",
+        "precision": "year",
+        "source": "Think EP was originally released in 2017 under the artis"
+      }
     },
     {
       "title": "Unsound Existence (self-hosted version)",
@@ -8783,7 +8789,13 @@
       "imageUrl": "https://www.doerfelverse.com/art/your-chance.png",
       "feedId": "https-www-doerfelverse-com-feeds-your-chance-xml",
       "priority": "extended",
-      "lastUpdated": "2025-12-14T16:26:13.807Z"
+      "lastUpdated": "2025-12-14T16:26:13.807Z",
+      "originalRelease": {
+        "year": 2015,
+        "kind": "recorded",
+        "precision": "year",
+        "source": "ced with the help of our friend Anthony Picone, recorded in 2015."
+      }
     },
     {
       "title": "DFB Volume 1",
@@ -9484,7 +9496,13 @@
       "imageUrl": "https://www.doerfelverse.com/art/dfbv1.png",
       "feedId": "https-www-doerfelverse-com-feeds-dfbv1-xml",
       "priority": "extended",
-      "lastUpdated": "2025-12-14T16:26:13.847Z"
+      "lastUpdated": "2025-12-14T16:26:13.847Z",
+      "originalRelease": {
+        "year": 2007,
+        "kind": "recorded",
+        "precision": "year",
+        "source": "These were originally recorded live for a radio program in 2007 when we were al"
+      }
     },
     {
       "title": "Music From The Doerfel-Verse",
@@ -18081,7 +18099,13 @@
       "imageUrl": "https://www.doerfelverse.com/art/beware-of-banjo.png",
       "feedId": "https-www-sirtjthewrathful-com-wp-content-uploads-2023-07-beware-of-banjo-xml",
       "priority": "extended",
-      "lastUpdated": "2025-12-14T16:26:14.931Z"
+      "lastUpdated": "2025-12-14T16:26:14.931Z",
+      "originalRelease": {
+        "year": 2008,
+        "kind": "released",
+        "precision": "year",
+        "source": "In 2008, I locked mysel"
+      }
     },
     {
       "title": "Generation Gap",
@@ -18824,7 +18848,13 @@
       "imageUrl": "https://www.doerfelverse.com/art/generation-gap.png",
       "feedId": "https-www-doerfelverse-com-feeds-generation-gap-xml",
       "priority": "extended",
-      "lastUpdated": "2025-12-14T16:26:14.977Z"
+      "lastUpdated": "2025-12-14T16:26:14.977Z",
+      "originalRelease": {
+        "year": 2009,
+        "kind": "recorded",
+        "precision": "year",
+        "source": "In 2009 when Ben Doerfe"
+      }
     },
     {
       "title": "Phatty The Grasshopper",
@@ -20561,7 +20591,13 @@
       "imageUrl": "https://www.doerfelverse.com/art/dfbv2.png",
       "feedId": "https-www-doerfelverse-com-feeds-dfbv2-xml",
       "priority": "extended",
-      "lastUpdated": "2025-12-14T16:26:15.325Z"
+      "lastUpdated": "2025-12-14T16:26:15.325Z",
+      "originalRelease": {
+        "year": 2009,
+        "kind": "released",
+        "precision": "year",
+        "source": "I'm Looking For\" originally released on Patuxent Records in 2009."
+      }
     },
     {
       "title": "LNURL Testing Podcast",
@@ -31765,7 +31801,13 @@
       "imageUrl": "https://www.doerfelverse.com/art/jam-with-nate-small.gif",
       "feedId": "www-doerfelverse-com-feeds-jam-with-nate-xml",
       "priority": "extended",
-      "lastUpdated": "2025-12-14T16:26:16.160Z"
+      "lastUpdated": "2025-12-14T16:26:16.160Z",
+      "originalRelease": {
+        "year": 2025,
+        "kind": "recorded",
+        "precision": "day",
+        "source": "her with our favorite fiddling buddy, Nate Grower on Dec 2, 2025, slapped up two"
+      }
     },
     {
       "title": "Think EP LIVE!",
@@ -32524,7 +32566,13 @@
       "imageUrl": "https://www.doerfelverse.com/art/think-ep-live-2017.png",
       "feedId": "www-doerfelverse-com-feeds-think-ep-live-xml",
       "priority": "core",
-      "lastUpdated": "2025-12-14T16:26:16.161Z"
+      "lastUpdated": "2025-12-14T16:26:16.161Z",
+      "originalRelease": {
+        "year": 2017,
+        "kind": "recorded",
+        "precision": "year",
+        "source": "For this concert, we recorded audio and video, live in 2017, in Big Pine Ke"
+      }
     },
     {
       "title": "Them",
@@ -33502,7 +33550,13 @@
       "imageUrl": "https://www.doerfelverse.com/art/them.png",
       "feedId": "www-doerfelverse-com-feeds-them-xml",
       "priority": "extended",
-      "lastUpdated": "2026-04-29T23:18:58.411Z"
+      "lastUpdated": "2026-04-29T23:18:58.411Z",
+      "originalRelease": {
+        "year": 2019,
+        "kind": "released",
+        "precision": "year",
+        "source": "eased when we went by the band name, \"Fuel on Fire\" back in 2019."
+      }
     },
     {
       "title": "Wrathodies",

--- a/scripts/backfill-album-dates.ts
+++ b/scripts/backfill-album-dates.ts
@@ -15,24 +15,10 @@
 import fs from 'fs';
 import path from 'path';
 import { extractAlbumDate, resolveOriginalRelease } from '../lib/album-date';
+import { loadOriginalReleaseOverrides } from './feed-overrides';
 
 const FILES = ['public/static-albums.json', 'public/albums-static-cached.json'];
 const FEEDS_FILE = 'data/feeds.json';
-
-/** feedId -> curated originalReleaseYear, for the feeds that declare one. */
-function loadOverrides(): Record<string, number | null> {
-  const fullPath = path.join(process.cwd(), FEEDS_FILE);
-  if (!fs.existsSync(fullPath)) return {};
-
-  const feeds: any[] = JSON.parse(fs.readFileSync(fullPath, 'utf-8')).feeds || [];
-  const overrides: Record<string, number | null> = {};
-  feeds.forEach((feed) => {
-    if (Object.prototype.hasOwnProperty.call(feed, 'originalReleaseYear')) {
-      overrides[feed.id] = feed.originalReleaseYear;
-    }
-  });
-  return overrides;
-}
 
 /**
  * The dates we verified by hand when this extractor was written. The backfill
@@ -64,7 +50,7 @@ function main() {
   const authoritative = JSON.parse(fs.readFileSync(authoritativePath, 'utf-8'));
   const albums: any[] = authoritative.albums || [];
 
-  const overrides = loadOverrides();
+  const overrides = loadOriginalReleaseOverrides();
   const overrideCount = Object.keys(overrides).length;
   console.log(`📋 ${albums.length} albums in ${FILES[0]}`);
   console.log(`🔧 ${overrideCount} curated originalReleaseYear override(s) in ${FEEDS_FILE}\n`);
@@ -139,7 +125,7 @@ function main() {
 
     const data = JSON.parse(fs.readFileSync(fullPath, 'utf-8'));
     const list: any[] = data.albums || [];
-    let changed = 0;
+    let withDate = 0;
 
     for (const album of list) {
       const info = resolveOriginalRelease(
@@ -148,7 +134,7 @@ function main() {
       );
       if (info) {
         album.originalRelease = info;
-        changed++;
+        withDate++;
       } else {
         delete album.originalRelease;
       }
@@ -156,7 +142,7 @@ function main() {
 
     data.count = list.length;
     fs.writeFileSync(fullPath, JSON.stringify(data, null, 2));
-    console.log(`✅ ${file}: ${changed}/${list.length} albums given originalRelease`);
+    console.log(`✅ ${file}: ${withDate}/${list.length} albums carry originalRelease`);
   }
 
   console.log('\n🔄 Rebuilding album-index.json');

--- a/scripts/backfill-album-dates.ts
+++ b/scripts/backfill-album-dates.ts
@@ -1,0 +1,135 @@
+/**
+ * Backfill `originalRelease` onto the cached albums by re-running the description
+ * date extractor over the text already in the cache.
+ *
+ * Why not a full re-parse: private feeds (isPrivate: true) carry PRIVATE_FEED_URL
+ * in the committed JSON, so `regenerate-static-cache-direct.ts` can't reach them
+ * from a fresh checkout. The descriptions are already in the cache, and the
+ * extractor is pure text — no network needed.
+ *
+ * Idempotent: re-running produces the same result, and albums whose description
+ * no longer yields a date have the key removed.
+ *
+ * Run: npx tsx scripts/backfill-album-dates.ts
+ */
+import fs from 'fs';
+import path from 'path';
+import { extractAlbumDate } from '../lib/album-date';
+
+const FILES = ['public/static-albums.json', 'public/albums-static-cached.json'];
+
+/**
+ * The dates we verified by hand when this extractor was written. The backfill
+ * refuses to write if the extractor stops agreeing — this is the repo's stand-in
+ * for a unit test (same convention as scripts/reparse-affected.ts).
+ */
+const EXPECTED_YEARS: Record<string, number> = {
+  'Think EP': 2017,
+  'Think EP LIVE!': 2017,
+  Them: 2019,
+  'Your Chance': 2015,
+  'Jam with Nate': 2025,
+  'DFB Volume 1': 2007,
+  'DFB Volume 2': 2009,
+  'Beware of Banjo': 2008,
+  'Generation Gap': 2009,
+};
+
+/** Years in these descriptions are a birth date and a memorial lifespan, not album dates. */
+const MUST_NOT_MATCH = ['Autumn', 'Unsound Existence (self-hosted version)'];
+
+function fail(message: string): never {
+  console.error(`❌ ${message}`);
+  process.exit(1);
+}
+
+function main() {
+  const authoritativePath = path.join(process.cwd(), FILES[0]);
+  const authoritative = JSON.parse(fs.readFileSync(authoritativePath, 'utf-8'));
+  const albums: any[] = authoritative.albums || [];
+
+  console.log(`📋 ${albums.length} albums in ${FILES[0]}\n`);
+
+  // --- Verify the extractor still behaves before touching any file ---
+  const extracted = albums.map((album) => ({
+    title: album.title as string,
+    releaseDate: album.releaseDate as string,
+    info: extractAlbumDate(album.description),
+  }));
+  const byTitle = (title: string) => extracted.filter((e) => e.title === title)[0];
+
+  Object.keys(EXPECTED_YEARS).forEach((title) => {
+    const expectedYear = EXPECTED_YEARS[title];
+    const entry = byTitle(title);
+    if (!entry) fail(`expected album "${title}" is missing from the cache`);
+    if (!entry.info) fail(`"${title}" should yield ${expectedYear}, got nothing`);
+    if (entry.info.year !== expectedYear) {
+      fail(`"${title}" should yield ${expectedYear}, got ${entry.info.year}`);
+    }
+  });
+
+  MUST_NOT_MATCH.forEach((title) => {
+    const entry = byTitle(title);
+    if (entry && entry.info) {
+      fail(`"${title}" must not yield a date, got ${entry.info.year} from "${entry.info.source}"`);
+    }
+  });
+
+  const matched = extracted.filter((e) => e.info);
+  const unexpected = matched.filter((e) => !(e.title in EXPECTED_YEARS));
+  if (unexpected.length > 0) {
+    fail(
+      `unexpected matches (verify these by hand, then add them to EXPECTED_YEARS): ` +
+        unexpected.map((e) => `${e.title}=${e.info!.year}`).join(', ')
+    );
+  }
+  if (matched.length !== Object.keys(EXPECTED_YEARS).length) {
+    fail(`expected ${Object.keys(EXPECTED_YEARS).length} matches, got ${matched.length}`);
+  }
+
+  console.log(`✅ extractor checks passed: ${matched.length} matches, ${MUST_NOT_MATCH.length} traps rejected\n`);
+
+  // --- Report what will change ---
+  console.log('Album                                  pubDate year -> display year');
+  console.log('-'.repeat(70));
+  matched.forEach((entry) => {
+    const info = entry.info!;
+    const oldYear = new Date(entry.releaseDate).getFullYear();
+    const flag = oldYear === info.year ? '   ' : ' * ';
+    console.log(`${flag}${entry.title.padEnd(36)} ${oldYear}  ->  ${info.year}  (${info.kind})`);
+  });
+
+  // --- Write both cache files (CLAUDE.md: treat them as one set) ---
+  console.log('');
+  for (const file of FILES) {
+    const fullPath = path.join(process.cwd(), file);
+    if (!fs.existsSync(fullPath)) {
+      console.log(`⏭️  ${file} not present, skipping`);
+      continue;
+    }
+
+    const data = JSON.parse(fs.readFileSync(fullPath, 'utf-8'));
+    const list: any[] = data.albums || [];
+    let changed = 0;
+
+    for (const album of list) {
+      const info = extractAlbumDate(album.description);
+      if (info) {
+        album.originalRelease = info;
+        changed++;
+      } else {
+        delete album.originalRelease;
+      }
+    }
+
+    data.count = list.length;
+    fs.writeFileSync(fullPath, JSON.stringify(data, null, 2));
+    console.log(`✅ ${file}: ${changed}/${list.length} albums given originalRelease`);
+  }
+
+  console.log('\n🔄 Rebuilding album-index.json');
+  const { buildIndex } = require('./build-album-index.js');
+  buildIndex();
+}
+
+main();

--- a/scripts/backfill-album-dates.ts
+++ b/scripts/backfill-album-dates.ts
@@ -14,9 +14,25 @@
  */
 import fs from 'fs';
 import path from 'path';
-import { extractAlbumDate } from '../lib/album-date';
+import { extractAlbumDate, resolveOriginalRelease } from '../lib/album-date';
 
 const FILES = ['public/static-albums.json', 'public/albums-static-cached.json'];
+const FEEDS_FILE = 'data/feeds.json';
+
+/** feedId -> curated originalReleaseYear, for the feeds that declare one. */
+function loadOverrides(): Record<string, number | null> {
+  const fullPath = path.join(process.cwd(), FEEDS_FILE);
+  if (!fs.existsSync(fullPath)) return {};
+
+  const feeds: any[] = JSON.parse(fs.readFileSync(fullPath, 'utf-8')).feeds || [];
+  const overrides: Record<string, number | null> = {};
+  feeds.forEach((feed) => {
+    if (Object.prototype.hasOwnProperty.call(feed, 'originalReleaseYear')) {
+      overrides[feed.id] = feed.originalReleaseYear;
+    }
+  });
+  return overrides;
+}
 
 /**
  * The dates we verified by hand when this extractor was written. The backfill
@@ -48,11 +64,15 @@ function main() {
   const authoritative = JSON.parse(fs.readFileSync(authoritativePath, 'utf-8'));
   const albums: any[] = authoritative.albums || [];
 
-  console.log(`📋 ${albums.length} albums in ${FILES[0]}\n`);
+  const overrides = loadOverrides();
+  const overrideCount = Object.keys(overrides).length;
+  console.log(`📋 ${albums.length} albums in ${FILES[0]}`);
+  console.log(`🔧 ${overrideCount} curated originalReleaseYear override(s) in ${FEEDS_FILE}\n`);
 
   // --- Verify the extractor still behaves before touching any file ---
   const extracted = albums.map((album) => ({
     title: album.title as string,
+    feedId: album.feedId as string,
     releaseDate: album.releaseDate as string,
     info: extractAlbumDate(album.description),
   }));
@@ -89,14 +109,23 @@ function main() {
 
   console.log(`✅ extractor checks passed: ${matched.length} matches, ${MUST_NOT_MATCH.length} traps rejected\n`);
 
-  // --- Report what will change ---
+  // --- Report the resolved outcome, extractor plus any curated overrides ---
   console.log('Album                                  pubDate year -> display year');
-  console.log('-'.repeat(70));
-  matched.forEach((entry) => {
-    const info = entry.info!;
+  console.log('-'.repeat(76));
+  extracted.forEach((entry) => {
+    const hasOverride = Object.prototype.hasOwnProperty.call(overrides, entry.feedId);
+    const resolved = resolveOriginalRelease(entry.info, overrides[entry.feedId]);
+    if (!resolved && !hasOverride) return; // nothing to say about untouched albums
+
     const oldYear = new Date(entry.releaseDate).getFullYear();
-    const flag = oldYear === info.year ? '   ' : ' * ';
-    console.log(`${flag}${entry.title.padEnd(36)} ${oldYear}  ->  ${info.year}  (${info.kind})`);
+    const note = hasOverride
+      ? resolved
+        ? ' [override]'
+        : ' [override: suppressed, keeps feed year]'
+      : ` (${resolved!.kind})`;
+    const newYear = resolved ? resolved.year : oldYear;
+    const flag = oldYear === newYear ? '   ' : ' * ';
+    console.log(`${flag}${entry.title.padEnd(36)} ${oldYear}  ->  ${newYear}${note}`);
   });
 
   // --- Write both cache files (CLAUDE.md: treat them as one set) ---
@@ -113,7 +142,10 @@ function main() {
     let changed = 0;
 
     for (const album of list) {
-      const info = extractAlbumDate(album.description);
+      const info = resolveOriginalRelease(
+        extractAlbumDate(album.description),
+        overrides[album.feedId]
+      );
       if (info) {
         album.originalRelease = info;
         changed++;

--- a/scripts/feed-overrides.ts
+++ b/scripts/feed-overrides.ts
@@ -1,0 +1,32 @@
+/**
+ * Reads the hand-curated `originalReleaseYear` values out of data/feeds.json.
+ *
+ * Script-side only: it touches the filesystem, so it deliberately does not live
+ * in lib/album-date.ts, which client components on the homepage import. Pair the
+ * result with `resolveOriginalRelease` from lib/album-date.ts in any script that
+ * merges feed metadata onto a cached album.
+ */
+import fs from 'fs';
+import path from 'path';
+
+const FEEDS_FILE = 'data/feeds.json';
+
+/**
+ * feedId -> curated originalReleaseYear, for the feeds that declare one.
+ * A feed with no key is absent from the map, so `overrides[feedId]` is
+ * `undefined` and the extractor stays in charge; an explicit `null` is kept,
+ * because that means "suppress the extracted date".
+ */
+export function loadOriginalReleaseOverrides(): Record<string, number | null> {
+  const fullPath = path.join(process.cwd(), FEEDS_FILE);
+  if (!fs.existsSync(fullPath)) return {};
+
+  const feeds: any[] = JSON.parse(fs.readFileSync(fullPath, 'utf-8')).feeds || [];
+  const overrides: Record<string, number | null> = {};
+  feeds.forEach((feed) => {
+    if (Object.prototype.hasOwnProperty.call(feed, 'originalReleaseYear')) {
+      overrides[feed.id] = feed.originalReleaseYear;
+    }
+  });
+  return overrides;
+}

--- a/scripts/regenerate-static-cache-direct.ts
+++ b/scripts/regenerate-static-cache-direct.ts
@@ -7,6 +7,7 @@
 import fs from 'fs';
 import path from 'path';
 import { RSSParser } from '../lib/rss-parser';
+import { resolveOriginalRelease } from '../lib/album-date';
 
 interface FeedEntry {
   id: string;
@@ -16,6 +17,8 @@ interface FeedEntry {
   priority?: string;
   status?: string;
   trackFilter?: string;
+  /** Hand-curated year that beats the date mined from the description; null suppresses it. */
+  originalReleaseYear?: number | null;
 }
 
 interface FeedsData {
@@ -56,6 +59,9 @@ async function regenerateCache() {
           feedId: feed.id,
           feedUrl: feed.originalUrl,
           priority: feed.priority,
+          // A curated originalReleaseYear in feeds.json wins over the extractor,
+          // so hand-corrected years survive this full rebuild.
+          originalRelease: resolveOriginalRelease(album.originalRelease, feed.originalReleaseYear),
           lastUpdated: new Date().toISOString()
         };
 

--- a/scripts/reparse-affected.ts
+++ b/scripts/reparse-affected.ts
@@ -9,6 +9,8 @@
 import fs from 'fs';
 import path from 'path';
 import { RSSParser } from '../lib/rss-parser';
+import { resolveOriginalRelease } from '../lib/album-date';
+import { loadOriginalReleaseOverrides } from './feed-overrides';
 
 interface Target {
   publicUrl: string;
@@ -49,6 +51,8 @@ const FILES = [
 ];
 
 async function main() {
+  const overrides = loadOriginalReleaseOverrides();
+
   for (const target of TARGETS) {
     console.log(`\n🔄 ${target.feedId}`);
     const album = await RSSParser.parseAlbumFeed(target.publicUrl, target.trackFilter);
@@ -72,6 +76,10 @@ async function main() {
       feedId: target.feedId,
       feedUrl: target.redactInCache ? 'PRIVATE_FEED_URL' : target.publicUrl,
       priority: 'extended',
+      // A curated originalReleaseYear in feeds.json beats the date mined from the
+      // description, so hand-corrected years survive a reparse. This replaces the
+      // whole cache entry, so without it the curated year is silently dropped.
+      originalRelease: resolveOriginalRelease(album.originalRelease, overrides[target.feedId]),
       lastUpdated: new Date().toISOString(),
     };
 

--- a/scripts/reparse-them.ts
+++ b/scripts/reparse-them.ts
@@ -7,6 +7,8 @@
 import fs from 'fs';
 import path from 'path';
 import { RSSParser } from '../lib/rss-parser';
+import { resolveOriginalRelease } from '../lib/album-date';
+import { loadOriginalReleaseOverrides } from './feed-overrides';
 
 const PUBLIC_URL = 'https://www.doerfelverse.com/feeds/them.xml';
 const FEED_ID = 'www-doerfelverse-com-feeds-them-xml';
@@ -25,6 +27,13 @@ async function main() {
     feedId: FEED_ID,
     feedUrl: REDACTED_URL,
     priority: 'extended',
+    // A curated originalReleaseYear in feeds.json beats the date mined from the
+    // description, so hand-corrected years survive a reparse. This replaces the
+    // whole cache entry, so without it the curated year is silently dropped.
+    originalRelease: resolveOriginalRelease(
+      album.originalRelease,
+      loadOriginalReleaseOverrides()[FEED_ID]
+    ),
     lastUpdated: new Date().toISOString(),
   };
 


### PR DESCRIPTION
An album's releaseDate is the feed's RSS pubDate — when the v4v feed was
published, not when the music was made. Nine descriptions state the real
date, and eight of them were displaying a wrong year; "Them" showed 2026
for a 2019 record because its pubDate is future-dated.

Add lib/album-date.ts with extractAlbumDate(), which pulls the stated
recorded/released date out of the description, and getDisplayYear(), which
prefers it and falls back to the pubDate year. The parser now stores the
result as originalRelease, and the four year-display sites use the helper.

Extraction is context-aware so it doesn't mistake other dates for album
dates: sentences about births, deaths and weddings are skipped and
YYYY-YYYY lifespans stripped, which keeps Autumn's "born Jan 12, 2024"
and Unsound Existence's "Miles Fonda 1988-2023" out of the results.
Verified against all 50 cached descriptions: 9 correct extractions, 2
traps rejected, no false positives.

scripts/backfill-album-dates.ts populates the existing cache from the
description text already stored there — a full re-parse can't reach the
private feeds — and asserts the expected years before writing, serving as
the unit test the repo has no framework for.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VzjLWemByJTTTZqNHA2mPd